### PR TITLE
Add transactional sync logging and CLI visibility

### DIFF
--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -53,10 +53,16 @@ CREATE TABLE IF NOT EXISTS lots (
     bid_count INTEGER,
     opening_bid_eur REAL,
     current_bid_eur REAL,
+    current_bidder_label TEXT,
     current_bid_buyer_id INTEGER,
     buyer_fee_percent REAL,
+    buyer_fee_vat_percent REAL,
     vat_percent REAL,
     awarding_state TEXT,
+    total_example_price_eur REAL,
+    location_city TEXT,
+    location_country TEXT,
+    seller_allocation_note TEXT,
     FOREIGN KEY (auction_id) REFERENCES auctions (id) ON DELETE CASCADE,
     FOREIGN KEY (current_bid_buyer_id) REFERENCES buyers (id),
     UNIQUE (auction_id, lot_code)
@@ -135,12 +141,19 @@ CREATE INDEX IF NOT EXISTS idx_market_offers_buyer_id ON market_offers (buyer_id
 
 CREATE TABLE IF NOT EXISTS sync_runs (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    source TEXT,
-    started_at TEXT,
+    auction_code TEXT,
+    started_at TEXT NOT NULL,
     finished_at TEXT,
-    state TEXT,
+    status TEXT,
+    pages_scanned INTEGER DEFAULT 0,
+    lots_scanned INTEGER DEFAULT 0,
+    lots_updated INTEGER DEFAULT 0,
+    error_count INTEGER DEFAULT 0,
+    max_pages INTEGER,
+    dry_run INTEGER,
     notes TEXT
 );
+CREATE INDEX IF NOT EXISTS idx_sync_runs_auction_code ON sync_runs (auction_code);
 
 -- Additional tables (buyers, my_lot_positions, my_bids, products, etc.)
 -- should be added here following the full specification of the project.

--- a/troostwatch/cli/sync.py
+++ b/troostwatch/cli/sync.py
@@ -65,7 +65,15 @@ from ..sync.sync import sync_auction_to_db
     default=False,
     help="Enable verbose logging during the sync run.",
 )
-def sync(db_path: str, auction_code: str, auction_url: str, max_pages: int | None, dry_run: bool, delay_seconds: float, verbose: bool) -> None:
+def sync(
+    db_path: str,
+    auction_code: str,
+    auction_url: str,
+    max_pages: int | None,
+    dry_run: bool,
+    delay_seconds: float,
+    verbose: bool,
+) -> None:
     """Synchronize an auction into a local database.
 
     This command downloads the auction listing page (and subsequent pages if
@@ -79,7 +87,7 @@ def sync(db_path: str, auction_code: str, auction_url: str, max_pages: int | Non
         f"Syncing auction {auction_code} from {auction_url} into {db_path}..."
     )
     try:
-        sync_auction_to_db(
+        result = sync_auction_to_db(
             db_path=db_path,
             auction_code=auction_code,
             auction_url=auction_url,
@@ -88,6 +96,15 @@ def sync(db_path: str, auction_code: str, auction_url: str, max_pages: int | Non
             delay_seconds=delay_seconds,
             verbose=verbose,
         )
-        click.echo("Sync complete.")
     except Exception as exc:
         click.echo(f"Error during sync: {exc}")
+        return
+
+    click.echo(
+        f"Sync {result.status} (run #{result.run_id}): pages={result.pages_scanned}, "
+        f"lots scanned={result.lots_scanned}, lots updated={result.lots_updated}, errors={result.error_count}"
+    )
+    if result.errors:
+        click.echo("Errors:")
+        for err in result.errors:
+            click.echo(f"  - {err}")

--- a/troostwatch/db.py
+++ b/troostwatch/db.py
@@ -71,6 +71,12 @@ CREATE TABLE IF NOT EXISTS sync_runs (
     started_at TEXT NOT NULL,
     finished_at TEXT,
     status TEXT,
+    pages_scanned INTEGER DEFAULT 0,
+    lots_scanned INTEGER DEFAULT 0,
+    lots_updated INTEGER DEFAULT 0,
+    error_count INTEGER DEFAULT 0,
+    max_pages INTEGER,
+    dry_run INTEGER,
     notes TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_sync_runs_auction_code ON sync_runs (auction_code);

--- a/troostwatch/sync/sync.py
+++ b/troostwatch/sync/sync.py
@@ -1,78 +1,80 @@
-"""Placeholder synchronization module.
-
-This module currently contains stub functions for fetching auction pages,
-parsing the content and persisting it to the database. The actual
-implementation should download HTML, call the parsers and insert data
-into the SQLite database.
-"""
+"""Synchronization module for fetching and persisting auction data."""
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Iterable, List, Tuple, Optional
+from dataclasses import dataclass
+import html
 import re
 import time
-import html
-
+from typing import Iterable, List, Optional, Tuple
+from urllib.error import URLError, HTTPError
 from urllib.request import Request, urlopen
 
-from ..db import get_connection, ensure_core_schema, ensure_schema
-from ..parsers.lot_card import parse_lot_card
-from ..parsers.lot_detail import parse_lot_detail
+from ..db import ensure_core_schema, ensure_schema, get_connection, iso_utcnow
+from ..parsers.lot_card import LotCardData, parse_lot_card
+from ..parsers.lot_detail import LotDetailData, parse_lot_detail
 
 
-def _fetch_url(url: str) -> str:
-    """Fetch the contents of a URL and return the HTML as a string.
+@dataclass
+class PageResult:
+    url: str
+    html: str
 
-    Uses ``urllib.request`` to avoid external dependencies. If the request
-    fails, an empty string is returned.
 
-    Args:
-        url: The URL to fetch.
+@dataclass
+class SyncRunResult:
+    run_id: int | None
+    status: str
+    pages_scanned: int
+    lots_scanned: int
+    lots_updated: int
+    error_count: int
+    errors: list[str]
 
-    Returns:
-        The response body decoded as UTF‑8 (or empty string on error).
-    """
+
+def _log(message: str, verbose: bool) -> None:
+    if not verbose:
+        return
+    try:
+        import click
+
+        click.echo(message)
+    except ImportError:
+        print(message)
+
+
+def _fetch_url(url: str) -> Tuple[Optional[str], Optional[str]]:
+    """Fetch the contents of a URL and return HTML plus any error message."""
+
     try:
         req = Request(url, headers={"User-Agent": "troostwatch-sync/0.1"})
         with urlopen(req) as response:
-            # decode with fallback to latin1 if utf-8 fails
             data = response.read()
             try:
-                return data.decode("utf-8")
+                return data.decode("utf-8"), None
             except UnicodeDecodeError:
-                return data.decode("latin1")
-    except Exception:
-        return ""
+                return data.decode("latin1"), None
+    except (HTTPError, URLError) as exc:
+        return None, str(exc)
+    except Exception as exc:  # pragma: no cover - safety net
+        return None, str(exc)
 
 
 def _extract_page_urls(html_text: str, base_url: str) -> List[str]:
-    """Extract pagination URLs from an auction listing page.
-
-    This function looks for anchor tags containing page numbers and returns
-    absolute URLs. If no pagination is found, returns an empty list.
-
-    Args:
-        html_text: HTML content of the auction page.
-        base_url: The base URL to resolve relative links against.
-
-    Returns:
-        A list of absolute page URLs (excluding the current page).
-    """
     urls: List[str] = []
-    for match in re.finditer(r'<a[^>]+href=["\']([^"\']+)["\'][^>]*>\s*(\d+)\s*</a>', html_text, re.IGNORECASE):
+    for match in re.finditer(
+        r'<a[^>]+href=["\']([^"\']+)["\'][^>]*>\s*(\d+)\s*</a>',
+        html_text,
+        re.IGNORECASE,
+    ):
         link = match.group(1)
-        # Only consider links that look like pagination (contain a number in the anchor text)
-        # Skip anchors that contain javascript or mailto
         if link.startswith("javascript") or link.startswith("mailto"):
             continue
-        # Convert relative URLs to absolute URLs
         if link.startswith("/"):
             full_url = base_url.rstrip("/") + link
         elif link.startswith("http://") or link.startswith("https://"):
             full_url = link
         else:
-            # Relative path without leading slash: join with base directory
             if base_url.endswith("/"):
                 full_url = base_url + link
             else:
@@ -83,32 +85,177 @@ def _extract_page_urls(html_text: str, base_url: str) -> List[str]:
 
 
 def _iter_lot_card_blocks(page_html: str) -> Iterable[str]:
-    """Yield HTML snippets corresponding to individual lot cards from a page.
-
-    This parser searches for list items or divs with indicators that they
-    represent a lot card. It falls back to splitting on ``<li`` tags if
-    necessary. The goal is to provide reasonable chunks of HTML that can be
-    passed to :func:`parse_lot_card`.
-
-    Args:
-        page_html: The full HTML of a listing page.
-
-    Yields:
-        Strings containing the HTML of a single lot card.
-    """
-    # Try to find elements with data-cy="lot-card" (as used on Troostwijk)
-    pattern = re.compile(r'<(li|div)[^>]*data-cy=["\']lot-card["\'][^>]*>(.*?)</\1>', re.IGNORECASE | re.DOTALL)
+    pattern = re.compile(
+        r'<(li|div)[^>]*data-cy=["\']lot-card["\'][^>]*>(.*?)</\1>',
+        re.IGNORECASE | re.DOTALL,
+    )
     for match in pattern.finditer(page_html):
         yield match.group(0)
-    # Fallback: split on <li> tags if pattern yields nothing
     if not pattern.search(page_html):
         for part in re.split(r'<li[^>]*>', page_html, flags=re.IGNORECASE):
-            if 'Lot' in part:
-                # Attempt to reconstruct a minimal <li> block
-                end_idx = part.find('</li>')
+            if "Lot" in part:
+                end_idx = part.find("</li>")
                 if end_idx != -1:
-                    snippet = '<li>' + part[:end_idx] + '</li>'
+                    snippet = "<li>" + part[:end_idx] + "</li>"
                     yield snippet
+
+
+def _wait_and_fetch(url: str, *, last_fetch: Optional[float], delay_seconds: float) -> Tuple[Optional[str], Optional[str], float]:
+    if last_fetch is not None and delay_seconds > 0:
+        elapsed = time.time() - last_fetch
+        if elapsed < delay_seconds:
+            time.sleep(delay_seconds - elapsed)
+    html_text, error = _fetch_url(url)
+    return html_text, error, time.time()
+
+
+def _collect_pages(
+    auction_url: str,
+    *,
+    max_pages: int | None,
+    delay_seconds: float,
+    verbose: bool,
+) -> Tuple[List[PageResult], List[str], Optional[float]]:
+    pages: List[PageResult] = []
+    errors: List[str] = []
+    last_fetch: Optional[float] = None
+
+    first_html, err, last_fetch = _wait_and_fetch(
+        auction_url, last_fetch=last_fetch, delay_seconds=0
+    )
+    if not first_html:
+        errors.append(f"Failed to fetch first page {auction_url}: {err or 'empty response'}")
+        return pages, errors, last_fetch
+    pages.append(PageResult(url=auction_url, html=first_html))
+
+    page_urls = _extract_page_urls(first_html, auction_url)
+    target = max_pages if max_pages is not None else len(page_urls) + 1
+    for url in page_urls:
+        if len(pages) >= target:
+            break
+        for attempt in range(2):
+            html_text, err, last_fetch = _wait_and_fetch(
+                url, last_fetch=last_fetch, delay_seconds=delay_seconds
+            )
+            if html_text:
+                pages.append(PageResult(url=url, html=html_text))
+                _log(f"Fetched page {len(pages)} at {url}", verbose)
+                break
+            if attempt == 0:
+                _log(f"Retrying page {url} after error: {err}", verbose)
+        else:
+            errors.append(f"Failed to fetch page {url}: {err or 'empty response'}")
+    return pages, errors, last_fetch
+
+
+def _extract_auction_title(page_html: str) -> Optional[str]:
+    match_title = re.search(r"<title>(.*?)</title>", page_html, re.IGNORECASE | re.DOTALL)
+    if match_title:
+        return html.unescape(match_title.group(1)).strip()
+    match_h1 = re.search(r"<h1[^>]*>(.*?)</h1>", page_html, re.IGNORECASE | re.DOTALL)
+    if match_h1:
+        return _strip_tags(match_h1.group(1)).strip()
+    return None
+
+
+def _upsert_auction(conn, auction_code: str, auction_url: str, auction_title: str | None) -> int:
+    conn.execute(
+        """
+        INSERT INTO auctions (auction_code, title, url)
+        VALUES (?, ?, ?)
+        ON CONFLICT(auction_code) DO UPDATE SET
+            title = excluded.title,
+            url = excluded.url
+        """,
+        (auction_code, auction_title, auction_url),
+    )
+    cur = conn.execute("SELECT id FROM auctions WHERE auction_code = ?", (auction_code,))
+    row = cur.fetchone()
+    if not row:
+        raise RuntimeError("Failed to retrieve auction id after upsert")
+    return int(row[0])
+
+
+def _choose_value(*values: Optional[str | float | int | bool]):
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _upsert_lot(
+    conn,
+    auction_id: int,
+    card: LotCardData,
+    detail: LotDetailData,
+) -> None:
+    lot_title = detail.title or card.title
+    lot_url = detail.url or card.url
+    lot_state = detail.state or card.state
+    lot_opens_at = detail.opens_at or card.opens_at
+    lot_closing_current = detail.closing_time_current or card.closing_time_current
+    lot_closing_original = detail.closing_time_original
+    lot_bid_count = detail.bid_count if detail.bid_count is not None else card.bid_count
+    lot_opening_bid = _choose_value(detail.opening_bid_eur, card.price_eur if card.is_price_opening_bid else None)
+    lot_current_bid = _choose_value(detail.current_bid_eur, card.price_eur)
+    location_city = detail.location_city or card.location_city
+    location_country = detail.location_country or card.location_country
+
+    conn.execute(
+        """
+        INSERT INTO lots (
+            auction_id, lot_code, title, url, state, status, opens_at,
+            closing_time_current, closing_time_original, bid_count,
+            opening_bid_eur, current_bid_eur, current_bidder_label,
+            buyer_fee_percent, buyer_fee_vat_percent, vat_percent,
+            awarding_state, total_example_price_eur, location_city,
+            location_country, seller_allocation_note
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(auction_id, lot_code) DO UPDATE SET
+            title = excluded.title,
+            url = excluded.url,
+            state = excluded.state,
+            status = excluded.status,
+            opens_at = excluded.opens_at,
+            closing_time_current = excluded.closing_time_current,
+            closing_time_original = excluded.closing_time_original,
+            bid_count = excluded.bid_count,
+            opening_bid_eur = excluded.opening_bid_eur,
+            current_bid_eur = excluded.current_bid_eur,
+            current_bidder_label = excluded.current_bidder_label,
+            buyer_fee_percent = excluded.buyer_fee_percent,
+            buyer_fee_vat_percent = excluded.buyer_fee_vat_percent,
+            vat_percent = excluded.vat_percent,
+            awarding_state = excluded.awarding_state,
+            total_example_price_eur = excluded.total_example_price_eur,
+            location_city = excluded.location_city,
+            location_country = excluded.location_country,
+            seller_allocation_note = excluded.seller_allocation_note
+        """,
+        (
+            auction_id,
+            card.lot_code,
+            lot_title,
+            lot_url,
+            lot_state,
+            lot_state,
+            lot_opens_at,
+            lot_closing_current,
+            lot_closing_original,
+            lot_bid_count,
+            lot_opening_bid,
+            lot_current_bid,
+            detail.current_bidder_label,
+            detail.auction_fee_pct,
+            detail.auction_fee_vat_pct,
+            detail.vat_on_bid_pct,
+            detail.state,
+            detail.total_example_price_eur,
+            location_city,
+            location_country,
+            detail.seller_allocation_note,
+        ),
+    )
 
 
 def sync_auction_to_db(
@@ -119,169 +266,146 @@ def sync_auction_to_db(
     dry_run: bool = False,
     delay_seconds: float = 0.5,
     verbose: bool = False,
-) -> None:
-    """Synchronize a Troostwijk auction into a SQLite database.
+) -> SyncRunResult:
+    pages_scanned = 0
+    lots_scanned = 0
+    lots_updated = 0
+    errors: list[str] = []
+    status = "failed"
+    run_id: int | None = None
 
-    This function downloads the auction listing and detail pages, extracts
-    relevant information about each lot using the parsers, and inserts or
-    updates records in the database accordingly. It supports optional
-    pagination and can be run in dry‑run mode where no database writes occur.
-
-    Args:
-        db_path: Path to the SQLite database.
-        auction_code: The auction code to sync.
-        auction_url: The URL of the auction page.
-        max_pages: Optional limit on the number of pages to fetch. If None,
-            all discovered pages are processed.
-        dry_run: If True, do not write to the database (useful for testing).
-        delay_seconds: Delay between HTTP requests in seconds to avoid
-            hammering the server.
-    """
-    # Fetch the first page of the auction listing
-    first_html = _fetch_url(auction_url)
-    if not first_html:
-        return
-    # Extract additional page URLs from pagination
-    page_urls = _extract_page_urls(first_html, auction_url)
-    pages: List[Tuple[str, str]] = [(auction_url, first_html)]
-    # Respect max_pages if provided
-    count = 1
-    for url in page_urls:
-        if max_pages is not None and count >= max_pages:
-            break
-        # Throttle requests
-        time.sleep(delay_seconds)
-        html_text = _fetch_url(url)
-        if html_text:
-            pages.append((url, html_text))
-            count += 1
-    if verbose:
-        try:
-            import click
-            click.echo(f"Discovered {len(pages)} page(s) for auction {auction_code} (max_pages={max_pages or 'all'})")
-        except ImportError:
-            print(f"Discovered {len(pages)} page(s) for auction {auction_code} (max_pages={max_pages or 'all'})")
-    # Open database connection
     with get_connection(db_path) as conn:
-        # Ensure core and buyers schemas exist
         ensure_core_schema(conn)
         ensure_schema(conn)
-        # Upsert auction record
-        # Attempt to extract auction title from the first page (<title> or <h1>)
-        auction_title: Optional[str] = None
-        match_title = re.search(r'<title>(.*?)</title>', first_html, re.IGNORECASE | re.DOTALL)
-        if match_title:
-            auction_title = html.unescape(match_title.group(1)).strip()
-        match_h1 = re.search(r'<h1[^>]*>(.*?)</h1>', first_html, re.IGNORECASE | re.DOTALL)
-        if match_h1:
-            auction_title = _strip_tags(match_h1.group(1)).strip()  # type: ignore[name-defined]
-        # Insert auction if not exists
+
+        run_cur = conn.execute(
+            """
+            INSERT INTO sync_runs (
+                auction_code, started_at, status, max_pages, dry_run
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (auction_code, iso_utcnow(), "running", max_pages, 1 if dry_run else 0),
+        )
+        run_id = int(run_cur.lastrowid)
+        conn.commit()
+
+        pages, page_errors, last_fetch = _collect_pages(
+            auction_url,
+            max_pages=max_pages,
+            delay_seconds=delay_seconds,
+            verbose=verbose,
+        )
+        errors.extend(page_errors)
+        if not pages:
+            finished_at = iso_utcnow()
+            conn.execute(
+                """
+                UPDATE sync_runs SET status = ?, finished_at = ?,
+                    pages_scanned = ?, lots_scanned = ?, lots_updated = ?,
+                    error_count = ?, notes = ?
+                WHERE id = ?
+                """,
+                (
+                    "failed",
+                    finished_at,
+                    pages_scanned,
+                    lots_scanned,
+                    lots_updated,
+                    len(errors),
+                    "; ".join(errors) if errors else None,
+                    run_id,
+                ),
+            )
+            conn.commit()
+            return SyncRunResult(
+                run_id=run_id,
+                status="failed",
+                pages_scanned=pages_scanned,
+                lots_scanned=lots_scanned,
+                lots_updated=lots_updated,
+                error_count=len(errors),
+                errors=errors,
+            )
+
+        pages_scanned = len(pages)
+        auction_title = _extract_auction_title(pages[0].html)
+
+        try:
+            if not dry_run:
+                conn.execute("BEGIN")
+            auction_id = None
+            if not dry_run:
+                auction_id = _upsert_auction(conn, auction_code, auction_url, auction_title)
+
+            for page_idx, page in enumerate(pages, start=1):
+                _log(
+                    f"Processing page {page_idx}/{pages_scanned}: {page.url}",
+                    verbose,
+                )
+                for card_html in _iter_lot_card_blocks(page.html):
+                    card = parse_lot_card(card_html, auction_code, base_url=auction_url)
+                    lots_scanned += 1
+                    detail_html, err, last_fetch = _wait_and_fetch(
+                        card.url,
+                        last_fetch=last_fetch,
+                        delay_seconds=delay_seconds,
+                    )
+                    if not detail_html:
+                        errors.append(
+                            f"Failed to fetch detail for {card.lot_code} ({card.url}): {err or 'empty response'}"
+                        )
+                        continue
+                    detail = parse_lot_detail(detail_html, card.lot_code, base_url=auction_url)
+                    if not dry_run and auction_id is not None:
+                        _upsert_lot(conn, auction_id, card, detail)
+                        lots_updated += 1
+                        _log(
+                            f"  Upserted lot {card.lot_code}: bid €{detail.current_bid_eur or card.price_eur or 'n/a'}",
+                            verbose,
+                        )
+            if not dry_run:
+                conn.commit()
+            status = "success"
+        except Exception as exc:  # pragma: no cover - runtime protection
+            errors.append(str(exc))
+            if not dry_run:
+                conn.rollback()
+            status = "failed"
+
+        finished_at = iso_utcnow()
         conn.execute(
-            "INSERT OR IGNORE INTO auctions (auction_code, title, url) VALUES (?, ?, ?)",
-            (auction_code, auction_title, auction_url),
+            """
+            UPDATE sync_runs SET status = ?, finished_at = ?,
+                pages_scanned = ?, lots_scanned = ?, lots_updated = ?,
+                error_count = ?, notes = ?
+            WHERE id = ?
+            """,
+            (
+                status,
+                finished_at,
+                pages_scanned,
+                lots_scanned,
+                lots_updated,
+                len(errors),
+                "; ".join(errors) if errors else None,
+                run_id,
+            ),
         )
         conn.commit()
-        # Retrieve auction id
-        cur = conn.execute("SELECT id FROM auctions WHERE auction_code = ?", (auction_code,))
-        row = cur.fetchone()
-        if not row:
-            # If insertion failed and no row exists, abort
-            return
-        auction_id = row[0]
-        # Process each page and each lot card
-        for (page_idx, (page_url, page_html)) in enumerate(pages, start=1):
-            if verbose:
-                try:
-                    import click
-                    click.echo(f"Processing page {page_idx}/{len(pages)}: {page_url}")
-                except ImportError:
-                    print(f"Processing page {page_idx}/{len(pages)}: {page_url}")
-            for card_html in _iter_lot_card_blocks(page_html):
-                # Parse the card
-                card = parse_lot_card(card_html, auction_code, base_url=auction_url)
-                if verbose:
-                    try:
-                        import click
-                        click.echo(f"  Found lot card {card.lot_code}")
-                    except ImportError:
-                        print(f"  Found lot card {card.lot_code}")
-                # Fetch the detail page
-                detail_html = _fetch_url(card.url)
-                if not detail_html:
-                    continue
-                lot_code = card.lot_code
-                # Parse details
-                detail = parse_lot_detail(detail_html, lot_code, base_url=auction_url)
-                # Determine values for insertion/update
-                # Prefer detail values for bid count and current bid; fall back to card
-                lot_title = detail.title or card.title
-                lot_url = detail.url or card.url
-                lot_state = detail.state or card.state
-                lot_opens_at = detail.opens_at or None
-                lot_closing_current = detail.closing_time_current or None
-                lot_closing_original = detail.closing_time_original or None
-                lot_bid_count = detail.bid_count if detail.bid_count is not None else card.bid_count
-                lot_current_bid = (
-                    detail.current_bid_eur
-                    if detail.current_bid_eur is not None
-                    else card.price_eur
-                )
-                if dry_run:
-                    continue
-                # Attempt to update existing row first
-                update_cursor = conn.execute(
-                    """
-                    UPDATE lots
-                    SET title = ?, url = ?, state = ?, opens_at = ?,
-                        closing_time_current = ?, closing_time_original = ?, bid_count = ?, current_bid_eur = ?
-                    WHERE auction_id = ? AND lot_code = ?
-                    """,
-                    (
-                        lot_title,
-                        lot_url,
-                        lot_state,
-                        lot_opens_at,
-                        lot_closing_current,
-                        lot_closing_original,
-                        lot_bid_count,
-                        lot_current_bid,
-                        auction_id,
-                        lot_code,
-                    ),
-                )
-                if update_cursor.rowcount == 0:
-                    # Insert new lot
-                    conn.execute(
-                        """
-                        INSERT INTO lots (
-                            auction_id, lot_code, title, url, state, opens_at,
-                            closing_time_current, closing_time_original, bid_count, current_bid_eur
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                        (
-                            auction_id,
-                            lot_code,
-                            lot_title,
-                            lot_url,
-                            lot_state,
-                            lot_opens_at,
-                            lot_closing_current,
-                            lot_closing_original,
-                            lot_bid_count,
-                            lot_current_bid,
-                        ),
-                    )
-                if verbose:
-                    try:
-                        import click
-                        click.echo(f"  Upserted lot {lot_code}: current bid €{lot_current_bid or 'N/A'}")
-                    except ImportError:
-                        print(f"  Upserted lot {lot_code}: current bid €{lot_current_bid or 'N/A'}")
-        if not dry_run:
-            conn.commit()
 
-# Local helper for stripping HTML tags used in sync (simple fallback)
-_STRIP_TAG_RE = re.compile(r'<[^>]+>')
+    return SyncRunResult(
+        run_id=run_id,
+        status=status,
+        pages_scanned=pages_scanned,
+        lots_scanned=lots_scanned,
+        lots_updated=lots_updated,
+        error_count=len(errors),
+        errors=errors,
+    )
+
+
+_STRIP_TAG_RE = re.compile(r"<[^>]+>")
+
 
 def _strip_tags(text: str) -> str:
-    return _STRIP_TAG_RE.sub('', text)
+    return _STRIP_TAG_RE.sub("", text)


### PR DESCRIPTION
## Summary
- add richer sync_runs schema and transactional logging with counts and options
- refactor sync pipeline to respect delays, retry pages, and perform idempotent upserts with detailed lot fields
- surface sync progress/error summaries through CLI commands

## Testing
- python -m compileall troostwatch


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922af3b177c832bab400578ec022795)